### PR TITLE
Pull response from df

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install liesel
+        run: |
+          pip install liesel
+          pip list
+
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:

--- a/R/liesel.R
+++ b/R/liesel.R
@@ -92,7 +92,8 @@ liesel <- function(response,
                    builder = FALSE) {
   check_liesel_version()
   mb <- .lsl$DistRegBuilder()
-  mb$add_response(response, get_distribution(distribution))
+
+  mb$add_response(np_array(response), get_distribution(distribution))
   fill_mb(mb, response, predictors, data, knots, diagonalize_penalties)
   if (builder) mb else mb$build_model()
 }

--- a/R/liesel.R
+++ b/R/liesel.R
@@ -91,8 +91,10 @@ liesel <- function(response,
                    diagonalize_penalties = TRUE,
                    builder = FALSE) {
   check_liesel_version()
-  mb <- .lsl$DistRegBuilder()
+  response <- substitute(response)
+  response <- eval(response, data, parent.frame())
 
+  mb <- .lsl$DistRegBuilder()
   mb$add_response(np_array(response), get_distribution(distribution))
   fill_mb(mb, response, predictors, data, knots, diagonalize_penalties)
   if (builder) mb else mb$build_model()

--- a/R/liesel.R
+++ b/R/liesel.R
@@ -90,12 +90,36 @@ liesel <- function(response,
                    knots = NULL,
                    diagonalize_penalties = TRUE,
                    builder = FALSE) {
-  check_liesel_version()
-  response <- substitute(response)
-  response <- eval(response, data, parent.frame())
+    check_liesel_version()
 
-  mb <- .lsl$DistRegBuilder()
-  mb$add_response(np_array(response), get_distribution(distribution))
-  fill_mb(mb, response, predictors, data, knots, diagonalize_penalties)
-  if (builder) mb else mb$build_model()
+    response <- substitute(response)
+
+    response_name <- as.character(response)
+    response_in_env <- exists(response, parent.frame())
+    response_in_df <- response_name %in% names(df)
+
+    response <- eval(response, data, parent.frame())
+
+    if (response_in_env & response_in_df) {
+        message(
+          "Found response '",
+          response_name,
+          "' in parent environment *and* data. Using '",
+          response_name,
+          "' found in data."
+        )
+    } else if (response_in_env) {
+        message(
+          "Did not find response '",
+          response_name,
+          "' in data. Using '",
+          response_name,
+          "' found in parent environment."
+        )
+    }
+
+    mb <- .lsl$DistRegBuilder()
+    mb$add_response(np_array(response), get_distribution(distribution))
+    fill_mb(mb, response, predictors, data, knots, diagonalize_penalties)
+    if (builder) mb else mb$build_model()
 }

--- a/tests/testthat/test-rliesel.R
+++ b/tests/testthat/test-rliesel.R
@@ -103,7 +103,8 @@ test_that("liesel() works", {
   expect_s3_class(m, "liesel.model.model.Model")
 
   vars <- py_eval("dict(r.m.vars)")
-  expect_equal(vars$response$value, y)
+
+  expect_equal(as.numeric(vars$response$value), y, tolerance = 1e-7)
 
   expect_s3_class(
     vars$response$dist_node$init_dist(),

--- a/tests/testthat/test-rliesel.R
+++ b/tests/testthat/test-rliesel.R
@@ -6,7 +6,7 @@ n <- 10
 x <- runif(n)
 y <- rnorm(n, mean = x, sd = exp(x))
 data <- data.frame(x = x, y = y)
-use_tmp_liesel_venv()
+# use_tmp_liesel_venv()
 
 # initialize python. without this line, r crashes on my system
 py_config()


### PR DESCRIPTION
So far, `rliesel` did not allow the following pattern:

```r
df <- data.frame(z = rnorm(10))

model <- liesel(
    response = z,
    distribution = "Normal",
    predictors = list(
        loc = predictor(~1),
        scale = predictor(~1, inverse_link = "Exp")
    ),
    data = df
)
```

Instead, you had to manually pass the response object like so:

```r
df <- data.frame(z = rnorm(10))

model <- liesel(
    response = df$z,
    distribution = "Normal",
    predictors = list(
        loc = predictor(~1),
        scale = predictor(~1, inverse_link = "Exp")
    ),
    data = df
)
```

This PR implements the first version. The second version still works.