### PR TITLE
Bump Liesel version requirement to >=0.3

### DIFF
--- a/R/reticulate.R
+++ b/R/reticulate.R
@@ -8,7 +8,7 @@
 #' @importFrom reticulate import py_require
 
 .onLoad <- function(libname, pkgname) {
-  py_require("liesel>=0.2.4")
+  py_require("liesel>=0.3")
 
   .lsl <<- import("liesel.model", convert = FALSE, delay_load = TRUE)
   .lsld <<- import("liesel.distributions", convert = FALSE, delay_load = TRUE)


### PR DESCRIPTION
I'm not entirely sure why, but `py_require("liesel>=0.2.4")` resolves to Liesel v0.2.8. I was unable to reproduce this behavior with uv or pip, but anyway, it is probably a good idea to bump the version requirement, as Liesel v0.2.4 is almost two years old by now. `py_require("liesel>=0.3")` resolves to Liesel v0.3.3.